### PR TITLE
Fix double doors not closing

### DIFF
--- a/config/charset/tweaks.cfg
+++ b/config/charset/tweaks.cfg
@@ -1,0 +1,38 @@
+# Configuration file
+
+additions {
+    # Dye minecarts by right-clicking them! [default: true]
+    B:dyeableMinecarts=true
+
+    # Adds glass shards which drop from glass in a manner similar to glowstone dust. [default: true]
+    B:glassShards=true
+
+    # Adds a graphite item crafted from charcoal which acts as black dye. [default: true]
+    B:graphite=true
+}
+
+
+mobs {
+    # Control mob spawning. Upon enabling, refer to 'tweaks-mobcontrol.cfg'. [default: false]
+    B:mobControl=false
+}
+
+
+tweaks {
+    # Setting to 1 makes vanilla-type tools ineffective. Setting to 2 also tries to remove their recipes. [default: false]
+    B:disableVanillaStyleTools=false
+
+    # Make double doors open both at the same time when one is opened. [default: true]
+    B:doubleDoorAutoOpen=false
+
+    # Makes primed TNT hittable. [default: true]
+    B:improvedTNT=true
+
+    # Remove sprinting. [default: false]
+    B:noPlayerSprinting=false
+
+    # Allows you to play out your Zorro dreams. [default: true]
+    B:zorro=true
+}
+
+


### PR DESCRIPTION
Both charset and malisis doors makes double doors open together, but having both mods do this means double doors would shut, disabling this in charset fixes it.
